### PR TITLE
Add tests for telephony cleanup

### DIFF
--- a/app/models/telephony.rb
+++ b/app/models/telephony.rb
@@ -15,11 +15,8 @@ class Telephony
   end
 
   def self.receive(body, opts = {})
-    
-    return Rails.logger.info("skipping SMS receive('#{body}', '#{opts.inspect}')") if Rails.env.test?
-    
     responder = Responder.find_by_phone(opts[:from])
-    
+
     if responder
       # if txt msg from a responder, handle dispatcher/reporter interaction
       DispatchMessenger.new(responder).respond(body)

--- a/spec/models/telephony_spec.rb
+++ b/spec/models/telephony_spec.rb
@@ -3,5 +3,32 @@ require 'spec_helper'
 describe Telephony do
   describe '.client'
   describe '.send'
-  describe '.receive'
+
+  describe '.receive' do
+    let(:responder) { build(:user, :responder, phone: '6665554444', name: 'Roy the Responder') }
+
+    context 'when from a responder' do
+      let(:opts) { {from: responder.phone, body: 'Testing'} }
+
+      before do
+        allow(Responder).to receive(:find_by_phone).with('6665554444').and_return(responder)
+      end
+
+      it "creates an instance of DispatchMessenger with the responder" do
+        dispatch_messenger = double(:dispatch_messenger)
+        expect(dispatch_messenger).to receive(:respond).with('Body')
+        expect(DispatchMessenger).to receive(:new).with(responder).and_return(dispatch_messenger)
+        Telephony.receive('Body', opts)
+      end
+    end
+
+    context 'when from a reporter' do
+      let(:opts) { {from: '1234567890', body: 'Testing'} }
+
+      it "texts Jacob" do
+        expect(Telephony).to receive(:send).with("1234567890: Testing", to: '6507876770')
+        Telephony.receive('Body', opts)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Remove testing short circuit from `Telephony.receive` since we really
only care about not trying to `.send` messages.

The reporter test is a bit brittle due to coupling, but the code would
need some refactoring to do a less brittle test.